### PR TITLE
fix tests for symlinked temp path

### DIFF
--- a/t/lib.pl
+++ b/t/lib.pl
@@ -9,6 +9,7 @@ use Path::Class qw( dir file );
 use Path::Class ();
 use File::Spec;
 use Test::More;
+use Cwd;
 
 our $config;
 our $detect;
@@ -140,7 +141,7 @@ sub net_pwd
     $pwd =~ s{\\}{/}g;
   }
   
-  $pwd;
+  Cwd::abs_path $pwd;
 }
 
 1;

--- a/t/server_fs.t
+++ b/t/server_fs.t
@@ -4,10 +4,11 @@ use File::Spec;
 use Test::More;
 use Test::AnyEventFTPServer;
 use File::Temp qw( tempdir );
+use Cwd;
 
 foreach my $type (qw( FS FSRW ))
 {
-  my $tmp = tempdir( CLEANUP => 1 );
+  my $tmp = Cwd::abs_path tempdir( CLEANUP => 1 );
   my $tmp_unmodified = $tmp;
 
   if($^O eq 'MSWin32')


### PR DESCRIPTION
On MacOSX, /var is a symbolic link of /private/var.

```
t/client_remote.t ............................ 1/58
#   Failed test 'dir = /var/folders/hx/yktg6d_n1bnb0jnqw6wn049r0000gn/T/fSUP5fIlKE'
#   at t/client_remote.t line 32.
#          got: '/private/var/folders/hx/yktg6d_n1bnb0jnqw6wn049r0000gn/T/fSUP5fIlKE'
#     expected: '/var/folders/hx/yktg6d_n1bnb0jnqw6wn049r0000gn/T/fSUP5fIlKE'

#   Failed test 'dir = /var/folders/hx/yktg6d_n1bnb0jnqw6wn049r0000gn/T/fSUP5fIlKE'
#   at t/client_remote.t line 32.
#          got: '/private/var/folders/hx/yktg6d_n1bnb0jnqw6wn049r0000gn/T/fSUP5fIlKE'
#     expected: '/var/folders/hx/yktg6d_n1bnb0jnqw6wn049r0000gn/T/fSUP5fIlKE'
# Looks like you failed 2 tests of 58.
```
