### PR TITLE
Code cleanup

### DIFF
--- a/lib/AnyEvent/FTP/Client.pm
+++ b/lib/AnyEvent/FTP/Client.pm
@@ -148,7 +148,7 @@ has timeout => (
 
 =head2 passive
 
-If set to true (the default) then data will be transferred using the 
+If set to true (the default) then data will be transferred using the
 passive (PASV) command, meaning the server will open a port for the
 client to connect to.  If set to false then data will be transferred
 using data port (PORT) command, meaning the client will open a port
@@ -180,20 +180,20 @@ sub BUILD
     $self->_connected(0);
     delete $self->{handle};
   });
-  
+
   require ($self->passive
     ? 'AnyEvent/FTP/Client/Transfer/Passive.pm'
     : 'AnyEvent/FTP/Client/Transfer/Active.pm');
-  
+
   return;
 }
 
 =head1 METHODS
 
-Unless otherwise specified, these methods will return an AnyEvent condition variable 
-(AnyEvent->condvar) or an object that implements its interface (methods C<recv>, C<cb>).  
-On success the C<send> will be used on the condition variable, on failure C<croak> will be 
-used instead.  Unless otherwise specified the object sent (for both success and failure) 
+Unless otherwise specified, these methods will return an AnyEvent condition variable
+(AnyEvent->condvar) or an object that implements its interface (methods C<recv>, C<cb>).
+On success the C<send> will be used on the condition variable, on failure C<croak> will be
+used instead.  Unless otherwise specified the object sent (for both success and failure)
 will be an instance of L<AnyEvent::FTP::Client::Response>.
 
 As an example, here is a fairly thorough handling of a response to the standard FTP C<HELP>
@@ -244,7 +244,7 @@ The URI of the remote FTP server.  C<$uri> must be either an instance of L<URI> 
 scheme, or a string with an FTP URL.
 
 If you use this method to connect to the FTP server, connect will also attempt to login with
-the username and password specified in the URL (or anonymous FTP if no credentials are 
+the username and password specified in the URL (or anonymous FTP if no credentials are
 specified).
 
 If there is a path included in the URL, then connect will also do a C<CWD> so that you start
@@ -257,15 +257,15 @@ in that directory.
 sub connect
 {
   my($self, $host, $port) = @_;
-  
+
   if($host =~ /^ftp:/)
   {
     require URI;
     $host = URI->new($host);
   }
-  
+
   my $uri;
-  
+
   if(ref($host) && eval { $host->isa('URI') })
   {
     $uri = $host;
@@ -276,12 +276,12 @@ sub connect
   {
     $port //= 21;
   }
-  
+
   croak "Tried to reconnect while connected" if $self->_connected;
-  
+
   my $cv = AnyEvent->condvar;
   $self->_connected(1);
-  
+
   tcp_connect $host, $port, sub {
     my($fh) = @_;
     unless($fh)
@@ -291,14 +291,14 @@ sub connect
       $self->clear_command;
       return;
     }
-    
+
     # Get the IP address we are sending from for when
     # we use the PORT command (passive=0).
     $self->{my_ip} = do {
       my($port, $addr) = unpack_sockaddr_in getsockname $fh;
       inet_ntoa $addr;
     };
-    
+
     $self->{handle} = AnyEvent::Handle->new(
       fh       => $fh,
       on_error => sub {
@@ -312,7 +312,7 @@ sub connect
         $self->emit('close');
       },
     );
-    
+
     $self->on_next_response(sub {
       my $res = shift;
       return $cv->croak($res) unless $res->is_success;
@@ -332,18 +332,18 @@ sub connect
         $self->pop_command;
       }
     });
-    
+
     $self->{handle}->on_read(sub {
       $self->{handle}->push_read( line => sub {
         my($handle, $line) = @_;
         $self->process_message_line($line);
       });
     });
-    
-  }, sub { 
+
+  }, sub {
     $self->timeout;
   };
-  
+
   return $cv;
 }
 
@@ -398,7 +398,7 @@ local filename, which will be created and written to as data is received from th
 server.
 
  $client->retr('foo.txt', 'foo.txt');
- 
+
 =item subroutine reference / callback reference
 
 The contents of the file will be passed to the callback as they are received.
@@ -411,7 +411,7 @@ The contents of the file will be passed to the callback as they are received.
 
 =back
 
-In order to resume a transfer, you need to include the C<restart> option after the 
+In order to resume a transfer, you need to include the C<restart> option after the
 C<$local> argument.  Here is an example:
 
  # assumes foo.txt (partial download) exists in the current
@@ -471,7 +471,7 @@ local filename, which will be opened and read from in order to create the file o
 the server.
 
  $client->stor('foo.txt', 'foo.txt');
- 
+
 =back
 
 =cut
@@ -629,7 +629,7 @@ Gets the current working directory on the remote server.  This gets just the str
 representing the directory path instead of a L<AnyEvent::FTP::Client::Response> object.
 
 =cut
-  
+
 sub pwd
 {
   my($self) = @_;
@@ -637,7 +637,7 @@ sub pwd
   $self->push_command(['PWD'])->cb(sub {
     my $res = eval { shift->recv } // $@;
     my $dir = $res->get_dir;
-    if($dir) { $cv->send($dir) } 
+    if($dir) { $cv->send($dir) }
     else { $cv->croak($res) }
   });
   $cv;
@@ -670,7 +670,7 @@ Create a directory on the remote server.
 =head2 $client-E<gt>rmd( $path )
 
 Remove a directory on the remote server.
- 
+
 =head2 $client-E<gt>help
 
 Gets a list of commands understood by the server.
@@ -687,7 +687,7 @@ Specify the old name for renaming a file.  See C<rename> method for a shortcut.
 =head2 $client-E<gt>rnto
 
 Specify the new name for renaming a file.  See C<rename> method for a shortcut.
- 
+
 =head2 $client-E<gt>noop
 
 Don't do anything.  The server will send an OK reply.
@@ -728,8 +728,8 @@ to some servers, but is seldom used today in practice.  See RFC959 for details.
 
 =head2 $client-E<gt>size( $path )
 
-Get the size of the remote file specified by C<$path>.  This is an extension to the FTP 
-standard specified in RFC3659, and may not be implemented by older (or even newer) 
+Get the size of the remote file specified by C<$path>.  This is an extension to the FTP
+standard specified in RFC3659, and may not be implemented by older (or even newer)
 servers.
 
 Send the size of the file on success, instead of the response object.
@@ -757,9 +757,9 @@ specified in RFC3659, and may not be implemented by older (or even newer) server
 
 =cut
 
-(eval sprintf('sub %s { shift->push_command([ %s => @_])};1', lc $_, $_)) // die $@ 
+(eval sprintf('sub %s { shift->push_command([ %s => @_])};1', lc $_, $_)) // die $@
   for qw( CWD CDUP NOOP ALLO SYST TYPE STRU MODE REST MKD RMD STAT HELP DELE RNFR RNTO USER PASS ACCT MDTM );
-  
+
 =head2 $client-E<gt>quit
 
 Send the FTP C<QUIT> command and close the connection to the remote server.
@@ -770,13 +770,13 @@ sub quit
 {
   my($self) = @_;
   my $cv = AnyEvent->condvar;
-  
+
   my $res;
-  
+
   $self->push_command(['QUIT'])->cb(sub {
     $res = eval { shift->recv } // $@;
   });
-  
+
   my $save = $self->{event}->{close};
   $self->{event}->{close} = [ sub {
     if(defined $res && $res->is_success)
@@ -788,7 +788,7 @@ sub quit
     $_->() for @$save;
     $self->{event}->{close} = $save;
   } ];
-  
+
   return $cv;
 }
 
@@ -797,7 +797,7 @@ sub quit
 The C<site> method provides an interface to site specific FTP commands.  Many
 FTP servers will support an extended set of commands using the standard FTP
 C<SITE> command.  This command will not check to see if the site commands are
-supported by the remote server, so it is up to you to determine if you can 
+supported by the remote server, so it is up to you to determine if you can
 really use these interfaces yourself.
 
 =over 4

--- a/lib/AnyEvent/FTP/Client/Role/FetchTransfer.pm
+++ b/lib/AnyEvent/FTP/Client/Role/FetchTransfer.pm
@@ -11,11 +11,11 @@ use Moo::Role;
 sub xfer
 {
   my($self, $fh, $local) = @_;
-  
+
   my $handle = $self->handle($fh);
 
   return unless defined $local;
-  
+
   $handle->on_read(sub {
     $handle->push_read(sub {
       $local->($_[0]{rbuf});
@@ -27,10 +27,10 @@ sub xfer
 sub convert_local
 {
   my($self, $local) = @_;
-  
+
   return unless defined $local;
   return $local if ref($local) eq 'CODE';
-  
+
   if(ref($local) eq 'SCALAR')
   {
     return sub {
@@ -63,13 +63,13 @@ sub push_command
   my $cv = $self->{client}->push_command(
     @_,
   );
-  
+
   $cv->cb(sub {
     eval { $cv->recv };
     my $err = $@;
     $self->{cv}->croak($err) if $err;
   });
-  
+
   $self->on_eof(sub {
     $cv->cb(sub {
       my $res = eval { $cv->recv };

--- a/lib/AnyEvent/FTP/Client/Role/ListTransfer.pm
+++ b/lib/AnyEvent/FTP/Client/Role/ListTransfer.pm
@@ -11,7 +11,7 @@ use Moo::Role;
 sub xfer
 {
   my($self, $fh, $local) = @_;
-  
+
   my $handle = $self->handle($fh);
 
   $handle->on_read(sub {
@@ -35,13 +35,13 @@ sub push_command
   my $cv = $self->{client}->push_command(
     @_,
   );
-  
+
   $cv->cb(sub {
     eval { $cv->recv };
     my $err = $@;
     $self->{cv}->croak($err) if $err;
   });
-  
+
   $self->on_eof(sub {
     $cv->cb(sub {
       my $res = eval { $cv->recv };

--- a/lib/AnyEvent/FTP/Client/Role/ResponseBuffer.pm
+++ b/lib/AnyEvent/FTP/Client/Role/ResponseBuffer.pm
@@ -45,7 +45,7 @@ sub process_message_line
       );
       delete $self->{response_buffer}->{$_} for qw( code message );
       my $once = delete $self->{response_buffer}->{once};
-      $_->($response) 
+      $_->($response)
         for @{ $self->{response_buffer}->{each} }, @{ $once };
     }
   }

--- a/lib/AnyEvent/FTP/Client/Role/StoreTransfer.pm
+++ b/lib/AnyEvent/FTP/Client/Role/StoreTransfer.pm
@@ -11,11 +11,11 @@ use Moo::Role;
 sub xfer
 {
   my($self, $fh, $local) = @_;
-  
+
   my $handle = $self->handle($fh);
-  
+
   return unless defined $local;
-  
+
   $handle->on_drain(sub {
     my $data = $local->();
     if(defined $data)
@@ -32,10 +32,10 @@ sub xfer
 sub convert_local
 {
   my($self, $local) = @_;
-  
+
   return unless defined $local;
   return $local if ref($local) eq 'CODE';
-  
+
   if(ref($local) eq '')
   {
     open my $fh, '<', $local;

--- a/lib/AnyEvent/FTP/Client/Site/Base.pm
+++ b/lib/AnyEvent/FTP/Client/Site/Base.pm
@@ -17,5 +17,3 @@ sub BUILDARGS
 has client => ( is => 'ro', required => 1 );
 
 1;
-
-

--- a/lib/AnyEvent/FTP/Client/Site/Microsoft.pm
+++ b/lib/AnyEvent/FTP/Client/Site/Microsoft.pm
@@ -17,21 +17,21 @@ extends 'AnyEvent::FTP::Client::Site::Base';
  $client->connect('ftp://iisserver')->cb(sub {
    # toggle dir style
    $client->site->microsoft->dirstyle->cb(sub {
-   
+
      $client->list->cb(sub {
        my $list = shift
        # $list is in first style.
-       
+
        $client->site->microsoft->dirstyle->cb(sub {
-       
+
          $client->list->cb(sub {
            my $list = shift;
            # list is in second style.
          });
-       
+
        });
      });
-   
+
    });
  });
 

--- a/lib/AnyEvent/FTP/Client/Site/Proftpd.pm
+++ b/lib/AnyEvent/FTP/Client/Site/Proftpd.pm
@@ -45,8 +45,8 @@ Execute C<SITE SYMLINK> command.
 =cut
 
 sub utime   { shift->client->push_command([SITE => "UTIME $_[0] $_[1]"]   ) }
-sub mkdir   { shift->client->push_command([SITE => "MKDIR $_[0]"]         ) } 
-sub rmdir   { shift->client->push_command([SITE => "RMDIR $_[0]"]         ) } 
+sub mkdir   { shift->client->push_command([SITE => "MKDIR $_[0]"]         ) }
+sub rmdir   { shift->client->push_command([SITE => "RMDIR $_[0]"]         ) }
 sub symlink { shift->client->push_command([SITE => "SYMLINK $_[0] $_[1]"] ) }
 
 =head2 $client-E<gt>site-E<gt>proftpd-E<gt>ratio

--- a/lib/AnyEvent/FTP/Client/Transfer.pm
+++ b/lib/AnyEvent/FTP/Client/Transfer.pm
@@ -16,22 +16,22 @@ use Carp qw( confess );
  use AnyEvent::FTP::Client;
  my $client = AnyEvent::FTP::Client;
  $client->connect('ftp://ftp.cpan.org')->cb(sub {
- 
+
    # $upload_transfer and $download_transfer are instances of
    # AnyEvent::FTP::Client::Transfer
    my $upload_transfer = $client->stor('remote_filename.txt', 'content');
-   
+
    my $buffer;
    my $download_transfer = $client->retr('remote_filename.txt', \$buffer);
- 
+
  });
 
 =head1 DESCRIPTION
 
 This class represents a file transfer with a remote server.  Transfers
-may be initiated between a remote file name and a local object.  The 
+may be initiated between a remote file name and a local object.  The
 local object may be a regular scalar, reference to a scalar or a file
-handle, for details, see the C<stor>, C<stou>, C<appe> and C<retr> 
+handle, for details, see the C<stor>, C<stou>, C<appe> and C<retr>
 methods in L<AnyEvent::FTP::Client>.
 
 This documentation covers what you can do with the transfer object once it
@@ -63,7 +63,7 @@ This class provides these events:
 
 =head2 open
 
-Emitted when the data connection is opened, and passes in as its first argument 
+Emitted when the data connection is opened, and passes in as its first argument
 the L<AnyEvent::Handle> instance used to transfer the file.
 
  $xfer->on_open(sub {
@@ -74,7 +74,7 @@ the L<AnyEvent::Handle> instance used to transfer the file.
 =head2 close
 
 Emitted when the transfer is complete, either due to a successful transfer or
-the server returned a failure status.  Passes in the final 
+the server returned a failure status.  Passes in the final
 L<AnyEvent::FTP::Client::Response> message associated with the transfer.
 
  $xfer->on_close(sub {
@@ -131,8 +131,8 @@ has restart => (
 
 =head2 cb
 
-Register a callback with the transfer to be executed when the transfer 
-successfully completes, or fails. Works exactly like the L<AnyEvent> condition 
+Register a callback with the transfer to be executed when the transfer
+successfully completes, or fails. Works exactly like the L<AnyEvent> condition
 variable C<cb> method.
 
 =head2 ready
@@ -154,7 +154,7 @@ sub recv { shift->{cv}->recv }
 sub handle
 {
   my($self, $fh) = @_;
-  
+
   my $handle;
   $handle = AnyEvent::Handle->new(
     fh => $fh,
@@ -168,13 +168,13 @@ sub handle
       $handle->destroy;
     },
     # this avoids deep recursion exception error (usually
-    # a warning) in example fput.pl when the buffer is 
+    # a warning) in example fput.pl when the buffer is
     # small (1024 on my debian VM)
     autocork  => 1,
   );
-  
+
   $self->emit(open => $handle);
-  
+
   $handle;
 }
 

--- a/lib/AnyEvent/FTP/Client/Transfer/Active.pm
+++ b/lib/AnyEvent/FTP/Client/Transfer/Active.pm
@@ -15,22 +15,22 @@ extends 'AnyEvent::FTP::Client::Transfer';
 sub BUILD
 {
   my($self) = @_;
-  
+
   my $local = $self->convert_local($self->local);
-  
+
   my $count = 0;
   my $guard;
   $guard = tcp_server $self->client->{my_ip}, undef, sub {
     my($fh, $host, $port) = @_;
     # TODO double check the host/port combo here.
-    
+
     return close $fh if ++$count > 1;
-    
+
     undef $guard; # close to additional connections.
 
     $self->xfer($fh,$local);
   }, sub {
-  
+
     my($fh, $host, $port) = @_;
     my $ip_and_port = join(',', split(/\./, $self->client->{my_ip}), $port >> 8, $port & 0xff);
 
@@ -44,12 +44,12 @@ sub BUILD
       undef $w;
     });
   };
-  
+
   $self->cv->cb(sub {
     my $res = eval { shift->recv } // $@;
     $self->emit('close' => $res);
   });
-  
+
 }
 
 package AnyEvent::FTP::Client::Transfer::Active::Fetch;

--- a/lib/AnyEvent/FTP/Client/Transfer/Passive.pm
+++ b/lib/AnyEvent/FTP/Client/Transfer/Passive.pm
@@ -14,9 +14,9 @@ extends 'AnyEvent::FTP::Client::Transfer';
 sub BUILD
 {
   my($self) = @_;
-  
+
   my $local = $self->convert_local($self->local);
-  
+
   my $data_connection = sub {
     my $res = shift;
     return if $res->is_preliminary;
@@ -29,7 +29,7 @@ sub BUILD
         {
           return "unable to connect to data port: $!";
         }
-        
+
         $self->xfer($fh,$local);
       };
       return;

--- a/lib/AnyEvent/FTP/Response.pm
+++ b/lib/AnyEvent/FTP/Response.pm
@@ -54,7 +54,7 @@ Permanent negative reply
 =back
 
 Generally C<4xx> and C<5xx> messages are errors, where as C<1xx>, C<3xx> are various states of
-(at least so far) successful operations.  C<2xx> indicates a completely successful 
+(at least so far) successful operations.  C<2xx> indicates a completely successful
 operation.
 
 =cut
@@ -91,7 +91,7 @@ sub is_preliminary { shift->{code} =~ /^1/    }
 =head2 $res-E<gt>as_string
 
 Returns a string representation of the response.  This may not be exactly what was
-returned by the server, but will include the code and at least part of the message in 
+returned by the server, but will include the code and at least part of the message in
 a human readable format.
 
 You can also get this string by treating objects of this class as a string (using

--- a/lib/AnyEvent/FTP/Role/Event.pm
+++ b/lib/AnyEvent/FTP/Role/Event.pm
@@ -11,15 +11,15 @@ use Moo::Role;
 =head1 SYNOPSIS
 
  package AnyEvent::FTP::Foo;
- 
+
  use Moo;
  with 'AnyEvent::FTP::Role::Event';
  __PACKAGE__->define_events(qw( error good ));
- 
+
  sub some_method
  {
    my($self) = @_;
-   
+
    if($self->other_method)
    {
      $self->emit(good => 'paylod message');
@@ -33,7 +33,7 @@ use Moo::Role;
 later on somewhere else
 
  use AnyEvent::FTP::Foo;
- 
+
  my $foo = AnyEvent::FTP::Foo->new;
  $foo->on_good(sub {
    my($message) = @_;
@@ -43,7 +43,7 @@ later on somewhere else
    my($message) = @_;
    print "failed: $message";
  });
- 
+
  $foo->some_method
 
 =head1 DESCRIPTION
@@ -66,11 +66,11 @@ which can be used to add callbacks to events.
 sub define_events
 {
   my $class = shift;
-  
+
   foreach my $name (@_)
   {
     my $method_name = join '::', $class, "on_$name";
-    my $method = sub { 
+    my $method = sub {
       my($self, $cb) = @_;
       push @{ $self->{event}->{$name} }, $cb;
       $self;

--- a/lib/AnyEvent/FTP/Server.pm
+++ b/lib/AnyEvent/FTP/Server.pm
@@ -16,7 +16,7 @@ use Socket qw( unpack_sockaddr_in inet_ntoa );
 
  use AnyEvent;
  use AnyEvent::FTP::Server;
- 
+
  my $server = AnyEvent::FTP::Server->new;
  $server->start;
  AnyEvent->condvar->recv;
@@ -25,7 +25,7 @@ use Socket qw( unpack_sockaddr_in inet_ntoa );
 
 B<CAUTION> L<AnyEvent::FTP::Server> hasn't been audited by anyone, including
 its author, in order to ensure that it is secure.  It is intended to be used
-primarily in testing the companion client L<AnyEvent::FTP::Client>.  It can 
+primarily in testing the companion client L<AnyEvent::FTP::Client>.  It can
 also be used to write your own context or personality (to use the L<Net::FTPServer>
 terminology) that use alternate back ends (say a database or memory store)
 that could theoretically be made to be secure, but you will need to carefully
@@ -36,7 +36,7 @@ This class is used for L<AnyEvent::FTP> server instances.
 Each time a client connects to the server a L<AnyEvent::FTP::Server::Connection>
 instance is created to manage the TCP connection.  Each connection
 also has a L<AnyEvent::FTP::Server::Context> which defines the behavior or
-personality of the server, and each context instance keeps track of the 
+personality of the server, and each context instance keeps track of the
 current directory, user authentication and authorization status of each
 connected client.
 
@@ -143,7 +143,7 @@ sub start
 sub _start_inet
 {
   my($self) = @_;
-  
+
   my $con = AnyEvent::FTP::Server::Connection->new(
     context => $self->{default_context}->new,
     ip      => do {
@@ -170,7 +170,7 @@ sub _start_inet
         undef $con;
       },
   );
-  
+
   $self->emit(connect => $con);
 
   STDOUT->autoflush(1);
@@ -180,37 +180,37 @@ sub _start_inet
     my($raw) = @_;
     print STDOUT $raw;
   });
-    
+
   $con->on_close(sub {
     close STDOUT;
     exit;
   });
-    
+
   $con->send_response(@{ $self->welcome });
-    
+
   $handle->on_read(sub {
     $handle->push_read( line => sub {
       my($handle, $line) = @_;
       $con->process_request($line);
     });
   });
-  
+
   $self;
 }
 
 sub _start_standalone
 {
   my($self) = @_;
-  
+
   my $prepare = sub {
     my($fh, $host, $port) = @_;
     $self->bindport($port);
     $self->emit(bind => $port);
   };
-  
+
   my $connect = sub {
     my($fh, $host, $port) = @_;
-    
+
     my $con = AnyEvent::FTP::Server::Connection->new(
       context => $self->{default_context}->new,
       ip => do {
@@ -218,7 +218,7 @@ sub _start_standalone
         inet_ntoa $addr;
       },
     );
-    
+
     my $handle;
     $handle = AnyEvent::Handle->new(
       fh       => $fh,
@@ -236,31 +236,31 @@ sub _start_standalone
         undef $con;
       },
     );
-    
+
     $self->emit(connect => $con);
-    
+
     $con->on_response(sub {
       my($raw) = @_;
       $handle->push_write($raw);
     });
-    
+
     $con->on_close(sub {
       $handle->push_shutdown;
     });
-    
+
     $con->send_response(@{ $self->welcome });
-    
+
     $handle->on_read(sub {
       $handle->push_read( line => sub {
         my($handle, $line) = @_;
         $con->process_request($line);
       });
     });
-  
+
   };
-  
+
   tcp_server $self->hostname, $self->port || undef, $connect, $prepare;
-  
+
   $self;
 }
 

--- a/lib/AnyEvent/FTP/Server/Connection.pm
+++ b/lib/AnyEvent/FTP/Server/Connection.pm
@@ -37,9 +37,9 @@ sub process_request
   my($self, $line) = @_;
 
   my $raw = $line;
-  
+
   $self->emit(request => $raw);
-  
+
   $line =~ s/\015?\012//g;
 
   if($line =~ s/^([A-Z]{1,4})\s?//i)
@@ -50,7 +50,7 @@ sub process_request
   {
     $self->context->invalid_syntax($self, $raw);
   }
-  
+
   $self;
 }
 
@@ -95,4 +95,3 @@ Process a single request. Returns the connection object ($conn).
 Sends the response. Returns the connection object ($conn).
 
 =cut
-

--- a/lib/AnyEvent/FTP/Server/Context.pm
+++ b/lib/AnyEvent/FTP/Server/Context.pm
@@ -26,20 +26,20 @@ has ascii_layer => (
 sub push_request
 {
   my($self, $con, $req) = @_;
-  
+
   push @{ $self->{request_queue} }, [ $con, $req ];
-  
+
   $self->process_queue if $self->ready;
-  
+
   $self;
 }
 
 sub process_queue
 {
   my($self) = @_;
-  
+
   return $self unless @{ $self->{request_queue} } > 0;
-  
+
   $self->ready(0);
 
   my($con, $req) = @{ shift @{ $self->{request_queue} } };
@@ -52,7 +52,7 @@ sub process_queue
   }
 
   my $method = join '_', 'cmd', $command;
-  
+
   if($self->can($method))
   {
     $self->$method($con, $req);
@@ -61,7 +61,7 @@ sub process_queue
   {
     $self->invalid_command($con, $req);
   }
-  
+
   $self;
 }
 

--- a/lib/AnyEvent/FTP/Server/Context/FS.pm
+++ b/lib/AnyEvent/FTP/Server/Context/FS.pm
@@ -15,7 +15,7 @@ extends 'AnyEvent::FTP::Server::Context';
 =head1 SYNOPSIS
 
  use AnyEvent::FTP::Server;
- 
+
  my $server = AnyEvent::FTP::Server->new(
    default_context => 'AnyEvent::FTP::Server::Context::FS',
  );
@@ -100,7 +100,7 @@ sub help_cwd { 'CWD <sp> pathname' }
 sub cmd_cwd
 {
   my($self, $con, $req) = @_;
-  
+
   my $dir = $req->args;
 
   eval {
@@ -112,7 +112,7 @@ sub cmd_cwd
     $con->send_response(250 => 'CWD command successful');
   };
   $con->send_response(550 => 'CWD error') if $@;
-  
+
   $self->done;
 }
 
@@ -125,7 +125,7 @@ sub help_cdup { 'CDUP' }
 sub cmd_cdup
 {
   my($self, $con, $req) = @_;
-  
+
   eval {
     use autodie;
     local $CWD = $self->cwd;
@@ -134,7 +134,7 @@ sub cmd_cdup
     $con->send_response(250 => 'CDUP command successful');
   };
   $con->send_response(550 => 'CDUP error') if $@;
-  
+
   $self->done;
 }
 
@@ -147,11 +147,11 @@ sub help_pwd { 'PWD' }
 sub cmd_pwd
 {
   my($self, $con, $req) = @_;
-  
+
   my $cwd = $self->cwd;
   if($^O eq 'MSWin32')
   {
-    (undef,$cwd) = File::Spec->splitpath($cwd,1);
+    (undef,$cwd) = File::Spec->splitpath($cwd, 1);
     $cwd =~ s{\\}{/}g;
   }
   $con->send_response(257 => "\"$cwd\" is the current directory");
@@ -167,7 +167,7 @@ sub help_size { 'SIZE <sp> pathname' }
 sub cmd_size
 {
   my($self, $con, $req) = @_;
-  
+
   eval {
     use autodie;
     local $CWD = $self->cwd;
@@ -201,7 +201,7 @@ sub help_mkd { 'MKD <sp> pathname' }
 sub cmd_mkd
 {
   my($self, $con, $req) = @_;
-  
+
   my $dir = $req->args;
   eval {
     use autodie;
@@ -222,7 +222,7 @@ sub help_rmd { 'RMD <sp> pathname' }
 sub cmd_rmd
 {
   my($self, $con, $req) = @_;
-  
+
   my $dir = $req->args;
   eval {
     use autodie;
@@ -243,7 +243,7 @@ sub help_dele { 'DELE <sp> pathname' }
 sub cmd_dele
 {
   my($self, $con, $req) = @_;
-  
+
   my $file = $req->args;
   eval {
     use autodie;
@@ -264,9 +264,9 @@ sub help_rnfr { 'RNFR <sp> pathname' }
 sub cmd_rnfr
 {
   my($self, $con, $req) = @_;
-  
+
   my $path = $req->args;
-  
+
   if($path)
   {
     eval {
@@ -307,9 +307,9 @@ sub help_rnto { 'RNTO <sp> pathname' }
 sub cmd_rnto
 {
   my($self, $con, $req) = @_;
-  
+
   my $path = $req->args;
-  
+
   if(! defined $self->rename_from)
   {
     $con->send_response(503 => 'Bad sequence of commands');
@@ -323,7 +323,7 @@ sub cmd_rnto
     eval {
       local $CWD = $self->cwd;
       if(! -e $path)
-      {        
+      {
         rename $self->rename_from, $path;
         $con->send_response(250 => 'Rename successful');
       }
@@ -350,9 +350,9 @@ sub help_stat { 'STAT [<sp> pathname]' }
 sub cmd_stat
 {
   my($self, $con, $req) = @_;
-  
+
   my $path = $req->args;
-  
+
   if($path)
   {
     do {
@@ -385,4 +385,3 @@ sub cmd_stat
 =back
 
 =cut
-

--- a/lib/AnyEvent/FTP/Server/Context/FSRO.pm
+++ b/lib/AnyEvent/FTP/Server/Context/FSRO.pm
@@ -13,7 +13,7 @@ extends 'AnyEvent::FTP::Server::Context::FSRW';
 =head1 SYNOPSIS
 
  use AnyEvent::FTP::Server;
- 
+
  my $server = AnyEvent::FTP::Server->new(
    default_context => 'AnyEvent::FTP::Server::Context::FSRO',
  );
@@ -66,4 +66,3 @@ sub cmd_stor
 =back
 
 =cut
-

--- a/lib/AnyEvent/FTP/Server/Context/FSRW.pm
+++ b/lib/AnyEvent/FTP/Server/Context/FSRW.pm
@@ -16,7 +16,7 @@ extends 'AnyEvent::FTP::Server::Context::FS';
 =head1 SYNOPSIS
 
  use AnyEvent::FTP::Server;
- 
+
  my $server = AnyEvent::FTP::Server->new(
    default_context => 'AnyEvent::FTP::Server::Context::FSRW',
  );
@@ -67,19 +67,19 @@ sub help_retr { 'RETR <sp> pathname' }
 sub cmd_retr
 {
   my($self, $con, $req) = @_;
-  
+
   my $fn = $req->args;
-  
+
   unless(defined $self->data)
   {
     $con->send_response(425 => 'Unable to build data connection');
     return;
   }
-  
+
   eval {
     use autodie;
     local $CWD = $self->cwd;
-    
+
     if(-f $fn)
     {
       # TODO: re-write so that this does not blocks
@@ -124,26 +124,26 @@ sub help_nlst { 'NLST [<sp> (pathname)]' }
 sub cmd_nlst
 {
   my($self, $con, $req) = @_;
-  
+
   my $dir = $req->args || '.';
-  
+
   unless(defined $self->data)
   {
     $con->send_response(425 => 'Unable to build data connection');
     return;
   }
-  
+
   eval {
     use autodie;
     local $CWD = $self->cwd;
-    
+
     $con->send_response(150 => "Opening ASCII mode data connection for file list");
     my $dh;
     opendir $dh, $dir;
-    my @list = 
-      map { $req->args ? join('/', $dir, $_) : $_ } 
-      sort 
-      grep !/^\.\.?$/, 
+    my @list =
+      map { $req->args ? join('/', $dir, $_) : $_ }
+      sort
+      grep !/^\.\.?$/,
       readdir $dh;
     closedir $dh;
     $self->data->push_write(join '', map { $_ . "\015\012" } @list);
@@ -171,20 +171,20 @@ sub help_list { 'LIST [<sp> pathname]' }
 sub cmd_list
 {
   my($self, $con, $req) = @_;
-  
+
   my $dir = $req->args || '.';
   $dir = '.' if $dir eq '-l';
-  
+
   unless(defined $self->data)
   {
     $con->send_response(425 => 'Unable to build data connection');
     return;
   }
-  
+
   eval {
     use autodie;
     local $CWD = $self->cwd;
-    
+
     $con->send_response(150 => "Opening ASCII mode data connection for file list");
     my $dh;
     opendir $dh, $dir;
@@ -217,13 +217,13 @@ sub cmd_stor
   my($self, $con, $req) = @_;
 
   my $fn = $req->args;
-  
+
   unless(defined $self->data)
   {
     $con->send_response(425 => 'Unable to build data connection');
     return;
   }
-  
+
   eval {
     use autodie;
     local $CWD = $self->cwd;
@@ -270,13 +270,13 @@ sub cmd_appe
   my($self, $con, $req) = @_;
 
   my $fn = $req->args;
-  
+
   unless(defined $self->data)
   {
     $con->send_response(425 => 'Unable to build data connection');
     return;
   }
-  
+
   eval {
     use autodie;
     local $CWD = $self->cwd;
@@ -323,13 +323,13 @@ sub cmd_stou
   my($self, $con, $req) = @_;
 
   my $fn = $req->args;
-  
+
   unless(defined $self->data)
   {
     $con->send_response(425 => 'Unable to build data connection');
     return;
   }
-  
+
   eval {
     use autodie;
     local $CWD = $self->cwd;
@@ -380,4 +380,3 @@ sub cmd_stou
 =back
 
 =cut
-

--- a/lib/AnyEvent/FTP/Server/Context/FSRW.pm
+++ b/lib/AnyEvent/FTP/Server/Context/FSRW.pm
@@ -5,7 +5,6 @@ use warnings;
 use 5.010;
 use Moo;
 use File::chdir;
-use File::Spec;
 use File::Temp qw( tempfile );
 
 extends 'AnyEvent::FTP::Server::Context::FS';

--- a/lib/AnyEvent/FTP/Server/Context/Memory.pm
+++ b/lib/AnyEvent/FTP/Server/Context/Memory.pm
@@ -16,14 +16,14 @@ extends 'AnyEvent::FTP::Server::Context';
 =head1 SYNOPSIS
 
  use AnyEvent::FTP::Server;
- 
+
  my $server = AnyEvent::FTP::Server->new(
    default_context => 'AnyEvent::FTP::Server::Context::Memory',
  );
 
 =head1 DESCRIPTION
 
-This class provides a context for L<AnyEvent::FTP::Server> which uses 
+This class provides a context for L<AnyEvent::FTP::Server> which uses
 memory to provide storage.  Once the server process terminates, all
 data stored is lost.
 
@@ -106,13 +106,13 @@ sub find
   $path = Path::Class::Dir->new_foreign('Unix', $path) unless ref $path;
   $path = Path::Class::Dir->new_foreign('Unix', $self->cwd, $path)
     unless $path->is_absolute;
-  
+
   my $store = $self->store;
 
   return $store if $path eq '/';
-  
+
   my @list = $path->components;
-  
+
   while(1)
   {
     my $i = first_index { $_ eq '..' } @list;
@@ -126,10 +126,10 @@ sub find
       splice @list, $i, 1;
     }
   }
-  
+
   shift @list; # shift off the root
   my $top = pop @list;
-  
+
   foreach my $part (@list)
   {
     if(exists($store->{$part}) && ref($store->{$part}) eq 'HASH')
@@ -141,7 +141,7 @@ sub find
       return;
     }
   }
-  
+
   if(exists $store->{$top})
   { return $store->{$top} }
   else
@@ -177,7 +177,7 @@ sub help_cwd { 'CWD <sp> pathname' }
 sub cmd_cwd
 {
   my($self, $con, $req) = @_;
-  
+
   my $dir = Path::Class::Dir->new_foreign('Unix', $req->args)->cleanup;
   $dir = $dir->absolute($self->cwd) unless $dir->is_absolute;
 
@@ -197,9 +197,9 @@ sub cmd_cwd
     }
   }
 
-  
+
   $dir = Path::Class::Dir->new_foreign('Unix', @list);
-  
+
   if(ref($self->find($dir)) eq 'HASH')
   {
     $self->cwd($dir);
@@ -234,7 +234,7 @@ sub cmd_cdup
   {
     $con->send_response(550 => 'CDUP error');
   }
-  
+
   $self->done;
 }
 
@@ -247,7 +247,7 @@ sub help_pwd { 'PWD' }
 sub cmd_pwd
 {
   my($self, $con, $req) = @_;
-  
+
   my $cwd = $self->cwd;
   $con->send_response(257 => "\"$cwd\" is the current directory");
   $self->done;
@@ -262,9 +262,9 @@ sub help_size { 'SIZE <sp> pathname' }
 sub cmd_size
 {
   my($self, $con, $req) = @_;
-  
+
   my $file = $self->find(Path::Class::File->new_foreign('Unix', $req->args));
-  
+
   if(defined($file) && !ref($file))
   {
     $con->send_response(213 => length $file);
@@ -277,7 +277,7 @@ sub cmd_size
   {
     $con->send_response(550 => $req->args . ": No such file or directory");
   }
-  
+
   $self->done;
 }
 
@@ -290,7 +290,7 @@ sub help_mkd { 'MKD <sp> pathname' }
 sub cmd_mkd
 {
   my($self, $con, $req) = @_;
-  
+
   my $path = Path::Class::Dir->new_foreign('Unix', $req->args);
   my $file = $self->find($path->parent);
   if($path->basename ne '' && defined($file) && ref($file) eq 'HASH')
@@ -321,7 +321,7 @@ sub help_rmd { 'RMD <sp> pathname' }
 sub cmd_rmd
 {
   my($self, $con, $req) = @_;
-  
+
   # TODO: be more picky about rmd and file or dele a directory
   my $path = Path::Class::Dir->new_foreign('Unix', $req->args);
   my $file = $self->find($path->parent);
@@ -354,7 +354,7 @@ sub help_dele { 'DELE <sp> pathname' }
 sub cmd_dele
 {
   my($self, $con, $req) = @_;
-  
+
   my $path = Path::Class::File->new_foreign('Unix', $req->args);
   my $file = $self->find($path->parent);
   if(defined($file) && ref($file) eq 'HASH')
@@ -385,7 +385,7 @@ sub help_rnfr { 'RNFR <sp> pathname' }
 sub cmd_rnfr
 {
   my($self, $con, $req) = @_;
-  
+
   my $path = Path::Class::File->new_foreign('Unix', $req->args);
   my $dir = $self->find($path->parent);
   if(ref($dir) eq 'HASH')
@@ -404,7 +404,7 @@ sub cmd_rnfr
   {
     $con->send_response(550 => 'No such file or directory');
   }
-  
+
   $self->done;
 }
 
@@ -417,7 +417,7 @@ sub help_rnto { 'RNTO <sp> pathname' }
 sub cmd_rnto
 {
   my($self, $con, $req) = @_;
-  
+
   my $from = $self->rename_from;
 
   unless(defined $from)
@@ -426,7 +426,7 @@ sub cmd_rnto
     $self->done;
     return;
   }
-  
+
   my $path = Path::Class::File->new_foreign('Unix', $req->args);
   my $dir = $self->find($path->parent);
 
@@ -460,7 +460,7 @@ sub cmd_stat
   my($self, $con, $req) = @_;
 
   my $file = $self->find($req->args);
-  
+
   if(defined $file)
   {
     if(ref($file) eq 'HASH')
@@ -488,15 +488,15 @@ sub help_nlst { 'NLST [<sp> (pathname)]' }
 sub cmd_nlst
 {
   my($self, $con, $req) = @_;
-  
+
   my $dir = $req->args;
-  
+
   unless(defined $self->data)
   {
     $con->send_response(425 => 'Unable to build data connection');
     return;
   }
-  
+
   eval {
     $con->send_response(150 => "Opening ASCII mode data connection for file list");
     my @list;

--- a/lib/AnyEvent/FTP/Server/OS/UNIX.pm
+++ b/lib/AnyEvent/FTP/Server/OS/UNIX.pm
@@ -11,7 +11,7 @@ use Moo;
 =head1 SYNOPSIS
 
  use AnyEvent::FTP::Server::OS::UNIX;
- 
+
  # interface using user fred
  my $unix = AnyEvent::FTP::Server::OS::UNIX->new('fred');
  $unix->jail;            # chroot
@@ -29,7 +29,7 @@ sub BUILDARGS
   my($class, $query) = @_;
   my($name, $pw, $uid, $gid, $quota, $comment, $gcos, $dir, $shell, $expire) = getpwnam $query;
   die "user not found" unless $name;
-  
+
   return {
     name  => $name,
     uid   => $uid,
@@ -115,10 +115,10 @@ Drop super user privileges
 sub drop_privileges
 {
   my($self) = @_;
-  
+
   $) = join ' ', $self->gid, $self->gid, @{ $self->groups };
   $> = $self->uid;
-  
+
   $( = $self->gid;
   $< = $self->uid;
 

--- a/lib/AnyEvent/FTP/Server/Role/Auth.pm
+++ b/lib/AnyEvent/FTP/Server/Role/Auth.pm
@@ -13,16 +13,16 @@ use Moo::Role;
 In your context:
 
  package AnyEvent::FTP::Server::Context::MyContext;
- 
+
  use Moo;
  extends 'AnyEvent::FTP::Server::Context';
  with 'AnyEvent::FTP::Server::Role::Auth';
- 
+
  has '+unauthenticated_safe_commands' => (
    default => sub { [ qw( USER PASS HELP QUIT FOO ) ] },
  );
- 
- # this command is deemed safe pre auth by 
+
+ # this command is deemed safe pre auth by
  # unauthenticated_safe_commands
  sub cmd_foo
  {
@@ -30,7 +30,7 @@ In your context:
    $con->send_response(211 => 'Here to stay');
    $self->done;
  }
- 
+
  # this command can pnly be executed after
  # authentication
  sub cmd_bar
@@ -43,20 +43,20 @@ In your context:
 Then when you create your server object:
 
  use AnyEvent:FTP::Server;
- 
+
  my $server = AnyEvent::FTP::Server->new;
  $server->on_connect(sub {
    # $con isa AnyEvent::FTP::Server::Connection
    my $con = shift;
    # $context isa AnyEvent::FTP::Server::Context::MyContext
    my $context = $con->context;
-   
+
    # allow login from user 'user' with password 'secret'
    $context->authenticator(sub {
      my($user, $pass) = @_;
      return $user eq 'user' && $pass eq 'secret';
    });
-   
+
    # make the client wait 5 seconds if they enter a
    # bad username / password
    $context->bad_authentication_delay(5);
@@ -128,7 +128,7 @@ has _safe_commands => (
 has unauthenticated_safe_commands => (
   is      => 'ro',
   lazy    => 1,
-  default => sub { 
+  default => sub {
     [qw( USER PASS HELP QUIT )]
   },
 );
@@ -164,11 +164,11 @@ sub help_user { 'USER <sp> username' }
 sub cmd_user
 {
   my($self, $con, $req) = @_;
-  
+
   my $user = $req->args;
   $user =~ s/^\s+//;
   $user =~ s/\s+$//;
-  
+
   if($user ne '')
   {
     $self->user($user);
@@ -178,7 +178,7 @@ sub cmd_user
   {
     $con->send_response(530 => "USER requires a parameter");
   }
-  
+
   $self->done;
 }
 
@@ -191,17 +191,17 @@ sub help_pass { 'PASS <sp> password' }
 sub cmd_pass
 {
   my($self, $con, $req) = @_;
-  
+
   my $user = $self->user;
   my $pass = $req->args;
-  
+
   unless(defined $user)
   {
     $con->send_response(503 => 'Login with USER first');
     $self->done;
     return;
   }
-  
+
   if($self->authenticator->($user, $pass))
   {
     $con->send_response(230 => "User $user logged in");

--- a/lib/AnyEvent/FTP/Server/Role/Help.pm
+++ b/lib/AnyEvent/FTP/Server/Role/Help.pm
@@ -55,7 +55,7 @@ sub help_help { 'HELP [<sp> command]' }
 sub cmd_help
 {
   my($self, $con, $req) = @_;
-  
+
   my $topic = $req->args;
   $topic =~ s/^\s+//;
   $topic =~ s/\s+$//;
@@ -67,11 +67,11 @@ sub cmd_help
     unless(defined $cmds{$class})
     {
       no strict 'refs';
-      $cmds{$class} = [ 
+      $cmds{$class} = [
         sort map { s/^cmd_//; uc $_ } grep /^cmd_/, keys %{$class . '::'}
       ];
     }
-  
+
     $con->send_response(214, [
       'The following commands are recognized:',
       join(' ', @{ $cmds{$class} }),
@@ -94,7 +94,7 @@ sub cmd_help
   {
     $con->send_response(502 => 'Unknown command');
   }
-  
+
   $self->done;
 }
 

--- a/lib/AnyEvent/FTP/Server/Role/Old.pm
+++ b/lib/AnyEvent/FTP/Server/Role/Old.pm
@@ -13,12 +13,12 @@ use Moo::Role;
 Create a context:
 
  package AnyEvent::FTP::Server::Context::MyContext;
- 
+
  use Moo;
- 
+
  extends 'AnyEvent::FTP::Server::Context';
  with 'AnyEvent::FTP::Server::Role::Old';
- 
+
  1;
 
 Use archaic FTP commands:

--- a/lib/AnyEvent/FTP/Server/Role/TransferPrep.pm
+++ b/lib/AnyEvent/FTP/Server/Role/TransferPrep.pm
@@ -14,7 +14,7 @@ use AnyEvent::Handle;
 =head1 SYNOPSIS
 
  package AnyEvent::FTP::Server::Context::MyContext;
- 
+
  use Moo;
  extends 'AnyEvent::FTP::Server::Context';
  with 'AnyEvent::FTP::Server::Role::TransferPrep';
@@ -78,7 +78,7 @@ sub help_pasv { 'PASV (returns address/port)' }
 sub cmd_pasv
 {
   my($self, $con, $req) = @_;
-  
+
   my $count = 0;
 
   tcp_server undef, undef, sub {
@@ -98,14 +98,14 @@ sub cmd_pasv
       },
       autocork => 1,
     );
-    
+
     $self->data($handle);
     # TODO this should be with the 227 message below.
     # demoting this to a TODO (was a F-I-X-M-E)
     # since I can't remember why I thought it needed
     # doing. plicease 12-05-2014
     $self->done;
-    
+
   }, sub {
     my($fh, $host, $port) = @_;
     my $ip_and_port = join(',', split(/\./, $con->ip), $port >> 8, $port & 0xff);
@@ -115,9 +115,9 @@ sub cmd_pasv
       $con->send_response(227 => "Entering Passive Mode ($ip_and_port)");
       undef $w;
     });
-    
+
   };
-  
+
   return;
 }
 
@@ -130,12 +130,12 @@ sub help_port { 'PORT <sp> h1,h2,h3,h4,p1,p2' }
 sub cmd_port
 {
   my($self, $con, $req) = @_;
-  
+
   if($req->args =~ /(\d+,\d+,\d+,\d+),(\d+),(\d+)/)
   {
     my $ip = join '.', split /,/, $1;
     my $port = $2*256 + $3;
-    
+
     tcp_connect $ip, $port, sub {
       my($fh) = @_;
       unless($fh)
@@ -144,7 +144,7 @@ sub cmd_port
         $self->done;
         return;
       }
-      
+
       my $handle;
       $handle = AnyEvent::Handle->new(
         fh => $fh,
@@ -157,13 +157,13 @@ sub cmd_port
           undef $handle;
         },
       );
-      
+
       $self->data($handle);
       $con->send_response(200 => "Port command successful");
       $self->done;
-      
+
     };
-    
+
   }
   else
   {
@@ -182,7 +182,7 @@ sub help_rest { 'REST <sp> byte-count' }
 sub cmd_rest
 {
   my($self, $con, $req) = @_;
-  
+
   if($req->args =~ /^\s*(\d+)\s*$/)
   {
     my $offset = $1;
@@ -201,4 +201,3 @@ sub cmd_rest
 =back
 
 =cut
-

--- a/lib/AnyEvent/FTP/Server/Role/Type.pm
+++ b/lib/AnyEvent/FTP/Server/Role/Type.pm
@@ -11,7 +11,7 @@ use Moo::Role;
 =head1 SYNOPSIS
 
  package AnyEvent::FTP::Server::Context::MyContext;
- 
+
  use Moo;
  extends 'AnyEvent::FTP::Server::Context';
  with 'AnyEvent::FTP::Server::Role::Type';
@@ -52,7 +52,7 @@ sub cmd_type
   my $type = uc $req->args;
   $type =~ s/^\s+//;
   $type =~ s/\s+$//;
-  
+
   if($type eq 'A' || $type eq 'I')
   {
     $self->type($type);
@@ -62,7 +62,7 @@ sub cmd_type
   {
     $con->send_response(500 => "Type not understood");
   }
-  
+
   $self->done;
 }
 

--- a/lib/AnyEvent/FTP/Server/UnambiguousResponseEncoder.pm
+++ b/lib/AnyEvent/FTP/Server/UnambiguousResponseEncoder.pm
@@ -36,10 +36,10 @@ L<AnyEvent::FTP::Response> object, or a code message pair.
 sub encode
 {
   my $self = shift;
-  
+
   my $code;
   my $message;
-  
+
   if(ref $_[0])
   {
     $code = $_[0]->code;
@@ -49,11 +49,11 @@ sub encode
   {
     ($code, $message) = @_;
   }
-  
+
   $message = [ $message ] unless ref($message) eq 'ARRAY';
-  
+
   my $last = pop @$message;
-  
+
   return join "\015\012", (map { "$code-$_" } @$message), "$code $last\015\012";
 }
 


### PR DESCRIPTION
This patch removes meaningless whitespace throughout the codebase, and removes at least one import of File::Spec which was not being used.
